### PR TITLE
Only show copy button on hover for code

### DIFF
--- a/gatsby-theme-doctornpm/src/components/code.js
+++ b/gatsby-theme-doctornpm/src/components/code.js
@@ -1,21 +1,26 @@
 import {Absolute, BorderBox, Relative, Text} from '@primer/components'
 import Highlight, {defaultProps} from 'prism-react-renderer'
 import githubTheme from 'prism-react-renderer/themes/github'
-import React from 'react'
+import React, {useState} from 'react'
 import ClipboardCopy from './clipboard-copy'
 import LiveCode from './live-code'
 
 function Code({className, children, live, noinline}) {
+  const [isMouseOverBlock, setIsMouseOverBlock] = useState(false)
+
   const language = className ? className.replace(/language-/, '') : ''
   const code = children.trim()
 
   if (live) {
     return <LiveCode code={code} language={language} noinline={noinline} />
   }
-
+  
   return (
-    <Relative>
-      <Absolute top={0} right={0} p={2}>
+    <Relative
+    onMouseEnter={() => setIsMouseOverBlock(true)}
+    onMouseLeave={() => setIsMouseOverBlock(false)}
+    >
+      <Absolute style={isMouseOverBlock ? {} : { display: 'none' }} top={0} right={0} p={2}>
         <ClipboardCopy value={code} />
       </Absolute>
       <Highlight

--- a/gatsby-theme-doctornpm/src/components/code.js
+++ b/gatsby-theme-doctornpm/src/components/code.js
@@ -14,7 +14,7 @@ function Code({className, children, live, noinline}) {
   if (live) {
     return <LiveCode code={code} language={language} noinline={noinline} />
   }
-  
+
   return (
     <Relative
     onMouseEnter={() => setIsMouseOverBlock(true)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
     },
     "docs": {
       "name": "doctornpm-example",
-      "version": "1.3.0",
+      "version": "1.7.0",
       "dependencies": {
-        "gatsby": "^2.32.3",
+        "gatsby": "^2.32.11",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-theme-doctornpm": "file:../gatsby-theme-doctornpm",
         "react": "^16.14.0",
@@ -21,7 +21,7 @@
       }
     },
     "gatsby-theme-doctornpm": {
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@babel/preset-env": "^7.5.5",
@@ -74,7 +74,7 @@
         "worker-loader": "^3.0.5"
       },
       "devDependencies": {
-        "gatsby": "^2.24.65",
+        "gatsby": "^2.32.11",
         "react": "^16.9.0",
         "react-dom": "^16.9.0"
       },
@@ -28958,6 +28958,7 @@
         "details-element-polyfill": "2.4.0",
         "jest-axe": "3.2.0",
         "polished": "3.5.2",
+        "react": "^16.10.2",
         "react-is": "16.10.2",
         "styled-system": "5.1.2"
       },
@@ -33343,7 +33344,7 @@
     "doctornpm-example": {
       "version": "file:docs",
       "requires": {
-        "gatsby": "^2.32.3",
+        "gatsby": "^2.32.11",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-theme-doctornpm": "file:../gatsby-theme-doctornpm",
         "react": "^16.14.0",
@@ -36678,7 +36679,7 @@
         "find-up": "^4.1.0",
         "framer-motion": "^1.4.2",
         "fuse.js": "^3.4.5",
-        "gatsby": "^2.24.65",
+        "gatsby": "^2.32.11",
         "gatsby-plugin-catch-links": "^2.1.2",
         "gatsby-plugin-manifest": "^2.2.1",
         "gatsby-plugin-mdx": "^1.0.13",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The copy button obscures text if it is at the end of the code block. This PR only shows the copy button on hover. See linked issue for more detail.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes npm/documentation#19
